### PR TITLE
Add step to verify checksum on helm version download

### DIFF
--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -289,8 +289,8 @@ func TestIsDirEmpty(t *testing.T) {
 
 }
 
-// TestCheckDirHasTGBin : create tg file in directory, check if exist
-func TestCheckDirHasTGBin(t *testing.T) {
+// TestCheckDirHasHelmBin : create Helm file in directory, check if exist
+func TestCheckDirHasHelmBin(t *testing.T) {
 
 	goarch := runtime.GOARCH
 	goos := runtime.GOOS
@@ -307,9 +307,9 @@ func TestCheckDirHasTGBin(t *testing.T) {
 
 	createFile(installLocation + installFile + "_" + goos + "_" + goarch)
 
-	empty := lib.CheckDirHasTGBin(installLocation, installFile)
+	empty := lib.CheckDirHasHelmBin(installLocation, installFile)
 
-	t.Logf("Expected directory to have tg file %v [expected]", installLocation+installFile+"_"+goos+"_"+goarch)
+	t.Logf("Expected directory to have Helm file %v [expected]", installLocation+installFile+"_"+goos+"_"+goarch)
 
 	if empty == true {
 		t.Logf("Directory empty")

--- a/lib/install.go
+++ b/lib/install.go
@@ -107,6 +107,7 @@ func Install(url string, appversion string, assets []modal.Repo, userBinPath *st
 	goarch := runtime.GOARCH
 	goos := runtime.GOOS
 	urlDownload := ""
+	chkDownload := ""
 
 	for _, v := range assets {
 
@@ -119,6 +120,7 @@ func Install(url string, appversion string, assets []modal.Repo, userBinPath *st
 					if matchedOS && matchedARCH {
 						// urlDownload = b.BrowserDownloadURL
 						urlDownload = "https://get.helm.sh/helm-" + v.TagName + "-" + goos + "-" + goarch + ".tar.gz"
+						chkDownload = urlDownload + ".sha256"
 						break
 					}
 				}
@@ -131,6 +133,13 @@ func Install(url string, appversion string, assets []modal.Repo, userBinPath *st
 	tarRead, readErr := os.Open(fileInstalled)
 	if readErr != nil {
 		fmt.Println("Expected a location, found " + fileInstalled)
+	}
+
+	chkInstalled, _ := DownloadFromURL(installLocation, chkDownload)
+	
+	verifySha := VerifyChecksum(fileInstalled, chkInstalled)
+	if verifySha != true {
+		log.Fatal("didn't pass the verify step")
 	}
 
 	/* untar the downloaded file*/

--- a/lib/symlink_test.go
+++ b/lib/symlink_test.go
@@ -13,9 +13,9 @@ import (
 // create symlink, check if symlink exist, remove symlink
 func TestCreateSymlink(t *testing.T) {
 
-	testSymlinkSrc := "/test-tgswitch-src"
+	testSymlinkSrc := "/test-helmswitch-src"
 
-	testSymlinkDest := "/test-tgswitch-dest"
+	testSymlinkDest := "/test-helmswitch-dest"
 
 	usr, errCurr := user.Current()
 	if errCurr != nil {
@@ -51,9 +51,9 @@ func TestCreateSymlink(t *testing.T) {
 // remove symlink, check if symlink exist
 func TestRemoveSymlink(t *testing.T) {
 
-	testSymlinkSrc := "/test-tgswitch-src"
+	testSymlinkSrc := "/test-helmswitch-src"
 
-	testSymlinkDest := "/test-tgswitch-dest"
+	testSymlinkDest := "/test-helmswitch-dest"
 
 	usr, errCurr := user.Current()
 	if errCurr != nil {
@@ -86,9 +86,9 @@ func TestRemoveSymlink(t *testing.T) {
 // TestCheckSymlink : Create symlink, test if file is symlink
 func TestCheckSymlink(t *testing.T) {
 
-	testSymlinkSrc := "/test-tgswitcher-src"
+	testSymlinkSrc := "/test-helmswitcher-src"
 
-	testSymlinkDest := "/test-tgswitcher-dest"
+	testSymlinkDest := "/test-helmswitcher-dest"
 
 	usr, errCurr := user.Current()
 	if errCurr != nil {

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	custBinPath := getopt.StringLong("bin", 'b', defaultBin, "Custom binary path. For example: /Users/username/bin/helm")
 	helpFlag := getopt.BoolLong("help", 'h', "displays help message")
-	versionFlag := getopt.BoolLong("version", 'v', "displays the version of tgswitch")
+	versionFlag := getopt.BoolLong("version", 'v', "displays the version of helmswitch")
 	_ = versionFlag
 
 	getopt.Parse()

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ const (
 	defaultBin = "/usr/local/bin/helm"
 )
 
-var version = "0.0.3\n"
+var version = "0.0.4\n"
 
 var clientID = "xxx"
 var clientSecret = "xxx"


### PR DESCRIPTION
Downloads sha256 file from get.helm.sh and compares the contents with checksum of downloaded helm file before switching to that version

Closes #5 