### PR TITLE
Checking if requested helm version is installed prior to scanning GitHub API

### DIFF
--- a/lib/install.go
+++ b/lib/install.go
@@ -6,13 +6,13 @@ import (
 	"os"
 	"os/user"
 	"regexp"
-	"runtime" 
+	"runtime"
 
 	"github.com/tokiwong/helm-switcher/modal"
 )
 
 const (
-	helmURL       = "https://get.helm.sh/"
+	helmURL        = "https://get.helm.sh/"
 	installFile    = "helm"
 	installVersion = "helm_"
 	binLocation    = "/usr/local/bin/helm"
@@ -76,22 +76,22 @@ func Install(url string, appversion string, assets []modal.Repo, userBinPath *st
 	}
 
 	/* check if selected version already downloaded */
-	fileExist := CheckFileExist(installLocation + installVersion + appversion)
+	// fileExist := CheckFileExist(installLocation + installVersion + appversion)
 
 	/* if selected version already exist, */
-	if fileExist {
+	// if fileExist {
 
-		/* remove current symlink if exist*/
-		symlinkExist := CheckSymlink(installedBinPath)
+	// 	/* remove current symlink if exist*/
+	// 	symlinkExist := CheckSymlink(installedBinPath)
 
-		if symlinkExist {
-			RemoveSymlink(installedBinPath)
-		}
-		/* set symlink to desired version */
-		CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
-		fmt.Printf("Switched helm to version %q \n", appversion)
-		return installLocation
-	}
+	// 	if symlinkExist {
+	// 		RemoveSymlink(installedBinPath)
+	// 	}
+	// 	/* set symlink to desired version */
+	// 	CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
+	// 	fmt.Printf("Switched helm to version %q \n", appversion)
+	// 	return installLocation
+	// }
 
 	/* remove current symlink if exist*/
 	symlinkExist := CheckSymlink(installedBinPath)
@@ -136,7 +136,6 @@ func Install(url string, appversion string, assets []modal.Repo, userBinPath *st
 	}
 
 	chkInstalled, _ := DownloadFromURL(installLocation, chkDownload)
-	
 	verifySha := VerifyChecksum(fileInstalled, chkInstalled)
 	if verifySha != true {
 		log.Fatal("didn't pass the verify step")

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/user"
 	"regexp"
 
 	"github.com/manifoldco/promptui"
@@ -13,8 +14,11 @@ import (
 )
 
 const (
-	helmURL    = "https://api.github.com/repos/helm/helm/releases?"
-	defaultBin = "/usr/local/bin/helm"
+	helmURL        = "https://api.github.com/repos/helm/helm/releases?"
+	defaultBin     = "/usr/local/bin/helm"
+	installFile    = "helm"
+	installVersion = "helm_"
+	installPath    = "/.helm.versions/"
 )
 
 var version = "0.0.4\n"
@@ -72,16 +76,45 @@ func main() {
 			if semverRegex.MatchString(args[0]) {
 				requestedVersion := args[0]
 
-				//check if version exist before downloading it
-				helmList, assets := lib.GetAppList(helmURL, &client)
-				exist := lib.VersionExist(requestedVersion, helmList)
-
-				if exist {
-					installLocation := lib.Install(helmURL, requestedVersion, assets, custBinPath)
-					lib.AddRecent(requestedVersion, installLocation) //add to recent file for faster lookup
-				} else {
-					fmt.Println("Not a valid helm version")
+				//check if version is already downloaded before checking if it exists
+				/* get current user */
+				usr, errCurr := user.Current()
+				if errCurr != nil {
+					log.Fatal(errCurr)
 				}
+				/* set installation location */
+				installLocation := usr.HomeDir + installPath
+
+				fileInstalled := lib.CheckFileExist(installLocation + installVersion + requestedVersion)
+
+				if fileInstalled {
+
+					/* remove current symlink if exist*/
+					symlinkExist := lib.CheckSymlink(defaultBin)
+
+					if symlinkExist {
+						lib.RemoveSymlink(defaultBin)
+					}
+					/* set symlink to desired version */
+					lib.CreateSymlink(installLocation+installVersion+requestedVersion, defaultBin)
+					fmt.Printf("Switched helm to version %q \n", requestedVersion)
+				} else {
+					//check if version exist before downloading it
+					fmt.Println(requestedVersion + " not found in install path " + installPath)
+					fmt.Println("Checking if the version exists...")
+
+					helmList, assets := lib.GetAppList(helmURL, &client)
+					exist := lib.VersionExist(requestedVersion, helmList)
+
+					if exist {
+						installLocation := lib.Install(helmURL, requestedVersion, assets, custBinPath)
+						lib.AddRecent(requestedVersion, installLocation) //add to recent file for faster lookup
+					} else {
+						fmt.Println("Not a valid helm version")
+					}
+
+				}
+
 			} else {
 				usageMessage()
 			}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ const (
 	installPath    = "/.helm.versions/"
 )
 
-var version = "0.0.4\n"
+var version = "0.0.5\n"
 
 var clientID = "xxx"
 var clientSecret = "xxx"


### PR DESCRIPTION
Fixes #11 

Moves the logic of checking if the file exists in the binpath before scanning GitHub API.  Effectively allows switching between versions locally/without touching the internet