### PR TITLE
Fix custom path usage when switching to already downloaded versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,13 +90,13 @@ func main() {
 				if fileInstalled {
 
 					/* remove current symlink if exist*/
-					symlinkExist := lib.CheckSymlink(defaultBin)
+					symlinkExist := lib.CheckSymlink(*custBinPath)
 
 					if symlinkExist {
-						lib.RemoveSymlink(defaultBin)
+						lib.RemoveSymlink(*custBinPath)
 					}
 					/* set symlink to desired version */
-					lib.CreateSymlink(installLocation+installVersion+requestedVersion, defaultBin)
+					lib.CreateSymlink(installLocation+installVersion+requestedVersion, *custBinPath)
 					fmt.Printf("Switched helm to version %q \n", requestedVersion)
 				} else {
 					//check if version exist before downloading it


### PR DESCRIPTION
Command "helmswitch -b ~/.local/bin/helm 3.6.1" does not switch the symlink to the specificied path.
As "custBinPath" is equal to "defaultBin" when no argument is specified, let's use it here.